### PR TITLE
[STREAMPIPES-124] Add docker-compose file for Redis

### DIFF
--- a/cli/services/redis/docker-compose.yml
+++ b/cli/services/redis/docker-compose.yml
@@ -13,23 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# lite or full (default: lite)
-deployment: lite
-pullPolicy: "Always"
+version: "2.0"
+services:
+  redis:
+    image: redis
+    environment:
+      # ALLOW_EMPTY_PASSWORD is recommended only for development.
+      - ALLOW_EMPTY_PASSWORD=yes
+    ports:
+      - 6379:6379
+    volumes:
+      - redis:/data/
+    entrypoint: redis-server --appendonly yes
+    restart: always
+    extra_hosts:
+      - host.docker.internal:${HOST_DOCKER_INTERNAL}
+    networks:
+      spnet:
 
-streampipes:
-  version: "0.67.0-SNAPSHOT"
-  registry: "apachestreampipes"
+volumes:
+  redis:
 
-external:
-  activemqVersion: 5.15.9
-  consulVersion: 1.7.1
-  couchdbVersion: 2.3.1
-  flinkVersion: 1.9.1-scala_2.11
-  kafkaVersion: 2.2.0
-  zookeeperVersion: 3.4.13
-  influxdbVersion: 1.7
-  iotdbVersion: latest
-  kibanaVersion: 6.2.3
-  elasticsearchVersion: 6.2.3
-  redisVersion: latest
+networks:
+  spnet:
+    external: true


### PR DESCRIPTION
Hi there,

This PR will add a docker-compose file for Redis. So that a user can just add ‘redis’ to the system file and a Redis container is then started with the rest of the system.

Fixes: https://issues.apache.org/jira/browse/STREAMPIPES-124

Thanks,
Grainier.