### PR TITLE
[STREAMPIPES-125] Add Redis as an optional external service

### DIFF
--- a/helm-chart/templates/optional-external-services/redis/redis-deployment.yaml
+++ b/helm-chart/templates/optional-external-services/redis/redis-deployment.yaml
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if eq .Values.deployment "full" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    db: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+        db: redis
+    spec:
+      volumes:
+        - name: redis-pv
+          persistentVolumeClaim:
+            claimName: redis-pvc
+      containers:
+        - name: redis
+          image: redis:{{ .Values.external.redisVersion }}
+          imagePullPolicy: {{ .Values.pullPolicy }}
+          args: ["--appendonly", "yes", "--save", "900", "1", "--save", "30", "1"]
+          tty: true
+          stdin: true
+          ports:
+            - containerPort: 6379
+          volumeMounts:
+            - mountPath: /data
+              name: redis-pv
+{{- end }}

--- a/helm-chart/templates/optional-external-services/redis/redis-pvc.yaml
+++ b/helm-chart/templates/optional-external-services/redis/redis-pvc.yaml
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if eq .Values.deployment "full" }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+{{- end}}

--- a/helm-chart/templates/optional-external-services/redis/redis-service.yaml
+++ b/helm-chart/templates/optional-external-services/redis/redis-service.yaml
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if eq .Values.deployment "full" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+spec:
+  selector:
+    db: redis
+  ports:
+    - name: main
+      protocol: TCP
+      port: 6379
+      targetPort: 6379
+{{- end}}


### PR DESCRIPTION
Hi there,

This PR will add Redis as an optional external service to be used in Kubernetes deployment.
Fixes: https://issues.apache.org/jira/browse/STREAMPIPES-125

Thanks,
Grainier.