### PR TITLE
[STREAMPIPES-312] Duplicate activemq svc definition in helm chart

### DIFF
--- a/k8s/templates/external/activemq/activemq-deployment.yaml
+++ b/k8s/templates/external/activemq/activemq-deployment.yaml
@@ -14,31 +14,6 @@
 # limitations under the License.
 
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: activemq
-spec:
-  selector:
-    app: activemq
-  ports:
-    - name: main
-      protocol: TCP
-      port: 61616
-      targetPort: 61616
-    - name: websocket
-      protocol: TCP
-      port: 61614
-      targetPort: 61614
-    - name: ui
-      protocol: TCP
-      port: 8161
-      targetPort: 8161
-    - name: mqtt
-      protocol: TCP
-      port: 1883
-      targetPort: 1883
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
<!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/getinvolved.html
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[STREAMPIPES-<Jira issue #>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][STREAMPIPES-<Jira issue #>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Be sure to keep the PR description updated to reflect all changes.
6. If possible, provide a concise example to reproduce the issue for a faster review.
7. Make sure tests pass via `mvn clean install`.
8. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
The k8s svc for activemq is defined multiple times in activemq-deployment.yaml and also in activemq-service.yaml file.
Because of this the helm install gives an error.

### Approach
removed duplicate svc definition of activemq in helm chart

### Samples


### Remarks
<!--
List related issues/PRs, link to discussions in the mailing list, todo items, or any other notes related to the PR.
-->
Fixes: https://issues.apache.org/jira/projects/STREAMPIPES/issues/STREAMPIPES-312