### PR TITLE
[STREAMPIPES-313] org.apache.streampipes.connect.adapter.exception.AdapterException: Could not resolve runtime configurations from http://connect-worker-main:8098

### DIFF
--- a/k8s/templates/extensions/connect-adapters/connect-worker-service.yaml
+++ b/k8s/templates/extensions/connect-adapters/connect-worker-service.yaml
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: connect-worker
+  name: connect-worker-main
 spec:
   selector:
     app: connect-worker


### PR DESCRIPTION
<!--
Thanks for contributing! Here are some tips you can follow to help us incorporate your contribution quickly and easily:
1. If this is your first time, please read our contributor guidelines:
    - https://streampipes.apache.org/getinvolved.html
    - https://cwiki.apache.org/confluence/display/STREAMPIPES/Getting+Started
2. Make sure the PR title is formatted like: `[STREAMPIPES-<Jira issue #>] PR title ...`
3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., `[WIP][STREAMPIPES-<Jira issue #>] PR title ...`.
4. Please write your PR title to summarize what this PR proposes/fixes.
5. Be sure to keep the PR description updated to reflect all changes.
6. If possible, provide a concise example to reproduce the issue for a faster review.
7. Make sure tests pass via `mvn clean install`.
8. (Optional) If the contribution is large, please file an Apache ICLA
    - http://apache.org/licenses/icla.pdf
-->

### Purpose
Seems like the backend is misconfigured to use "http://connect-worker-main:8098" instead of "http://connect-worker:8098", because the name k8s svc name is "connect-worker". So either the backend needs to be updated or the k8s svc name needs to be changed.

Steps to reproduce:
1) Deploy StreamPipes on k8s.
2) Open UI > Connect > Apache Kafka
3) Enter kafka host and port.
When its searching for kafka topics, check logs of backend.

### Approach
Change k8s svc name from "connect-worker" to "connect-worker-main"

### Samples


### Remarks
Fixes: https://issues.apache.org/jira/projects/STREAMPIPES/issues/STREAMPIPES-313?filter=allopenissues
