### PR TITLE
[STREAMPIPES-477] CLI logs service optional

### DIFF
--- a/cli/bin/commands/logs
+++ b/cli/bin/commands/logs
@@ -40,12 +40,11 @@ while [[ "$#" -gt 0 ]]; do
     case $1 in
         -f|--follow)
           if [ -n "$2" ] && [ ${2:0:1} != "-" ]; then
-            follow=true
             svc=$2
-            shift 2
-          else
-            fatal "Argument for $1 is missing" >&2
+            shift 1
           fi
+          follow=true
+          shift 1
           ;;
         -*|--*=) fatal "Unsupported flag $1, see 'streampipes ${0##*/} --help'" >&2 ;;
         *)


### PR DESCRIPTION

### Purpose
The CLI provides the feature to print logs of containers defined in the current env. 
Currently, the service name is required which needs some knowledge...

### Approach
Remove error message if value is not given

### Samples
 streampipes logs -f

Fixes:  https://issues.apache.org/jira/browse/STREAMPIPES-477
